### PR TITLE
Close unused AudioContext

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,9 @@ MediaRecorder.prototype = {
     if (this.state === 'inactive') {
       this.state = 'recording'
 
+      if (this.context) {
+        this.context.close();
+      }
       this.context = new AudioContext()
       var input = this.context.createMediaStreamSource(this.stream)
       var processor = this.context.createScriptProcessor(2048, 1, 1)


### PR DESCRIPTION
Repeated calls to `start()` and `stop()`, or simply using the buttons in the demo to start or stop AudioRecorder more than a few times, causes the browser to run out of `AudioContext`s ([see MDN](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/AudioContext#Usage_notes)). Should call `close()` before initialising a new `AudioContext`.