### PR TITLE
Add support for `error` event type

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,21 @@ function createWorker (fn) {
   return new Worker(URL.createObjectURL(blob))
 }
 
+/**
+ * Create a new Event of type 'error'
+ *
+ * @param {String} message The error message
+ * @return {Event} The error event
+ */
+function MediaRecorderErrorEvent (message) {
+  var event = new Event('error')
+  event.data = {
+    message: message
+  }
+
+  return event
+}
+
 var context
 
 /**
@@ -73,7 +88,12 @@ MediaRecorder.prototype = {
    */
   start: function start (timeslice) {
     if (this.state !== 'inactive') {
-      return this.em.dispatchEvent(new Event('error'))
+      return this.em.dispatchEvent(
+        MediaRecorderErrorEvent(
+          "Failed to execute 'start' on the MediaRecorder:" +
+          "The MediaRecorder's state is not 'inactive'."
+        )
+      )
     }
 
     this.state = 'recording'
@@ -86,13 +106,11 @@ MediaRecorder.prototype = {
 
     var recorder = this
     processor.onaudioprocess = function (e) {
-      if (this.state !== 'recording') {
-        return this.dispatchError(Error("Failed to process audio recording: The MediaRecorder's state is not 'recording'."))
+      if (recorder.state === 'recording') {
+        recorder.encoder.postMessage([
+          'encode', e.inputBuffer.getChannelData(0)
+        ])
       }
-
-      recorder.encoder.postMessage([
-        'encode', e.inputBuffer.getChannelData(0)
-      ])
     }
 
     input.connect(processor)
@@ -105,6 +123,8 @@ MediaRecorder.prototype = {
         if (recorder.state === 'recording') recorder.requestData()
       }, timeslice)
     }
+
+    return undefined
   },
 
   /**
@@ -119,12 +139,17 @@ MediaRecorder.prototype = {
    */
   stop: function stop () {
     if (this.state === 'inactive') {
-      return this.dispatchError(Error("Failed to execute 'stop' on the MediaRecorder: The MediaRecorder's state is 'inactive'."))
+      return this.em.dispatchEvent(
+        MediaRecorderErrorEvent(
+          "Failed to execute 'stop' on the MediaRecorder:" +
+          "The MediaRecorder's state is 'inactive'."
+        )
+      )
     }
 
     this.requestData()
     this.state = 'inactive'
-    clearInterval(this.slicing)
+    return clearInterval(this.slicing)
   },
 
   /**
@@ -139,11 +164,16 @@ MediaRecorder.prototype = {
    */
   pause: function pause () {
     if (this.state !== 'recording') {
-      return this.dispatchError(Error("Failed to execute 'pause' on the MediaRecorder: The MediaRecorder's state is not 'recording'."))
+      return this.em.dispatchEvent(
+        MediaRecorderErrorEvent(
+          "Failed to execute 'pause' on the MediaRecorder:" +
+          "The MediaRecorder's state is not 'recording'."
+        )
+      )
     }
 
     this.state = 'paused'
-    this.em.dispatchEvent(new Event('pause'))
+    return this.em.dispatchEvent(new Event('pause'))
   },
 
   /**
@@ -158,11 +188,16 @@ MediaRecorder.prototype = {
    */
   resume: function resume () {
     if (this.state !== 'paused') {
-      return this.dispatchError(Error("Failed to execute 'resume' on the MediaRecorder: The MediaRecorder's state is not 'paused'."))
+      return this.em.dispatchEvent(
+        MediaRecorderErrorEvent(
+          "Failed to execute 'resume' on the MediaRecorder:" +
+          "The MediaRecorder's state is not 'paused'."
+        )
+      )
     }
 
     this.state = 'recording'
-    this.em.dispatchEvent(new Event('resume'))
+    return this.em.dispatchEvent(new Event('resume'))
   },
 
   /**
@@ -177,16 +212,22 @@ MediaRecorder.prototype = {
    */
   requestData: function requestData () {
     if (this.state === 'inactive') {
-      return this.dispatchError(Error("Failed to execute 'requestData' on the MediaRecorder: The MediaRecorder's state is 'inactive'."))
+      return this.em.dispatchEvent(
+        MediaRecorderErrorEvent(
+          "Failed to execute 'requestData' on the MediaRecorder:" +
+          "The MediaRecorder's state is 'inactive'."
+        )
+      )
     }
 
-    this.encoder.postMessage(['dump', context.sampleRate])
+    return this.encoder.postMessage(['dump', context.sampleRate])
   },
 
   /**
    * Add listener for specified event type.
    *
-   * @param {"start"|"stop"|"pause"|"resume"|"dataavailable"|"error"} type Event type.
+   * @param {"start"|"stop"|"pause"|"resume"|"dataavailable"|"error"}
+   * type Event type.
    * @param {function} listener The listener function.
    *
    * @return {undefined}
@@ -203,7 +244,8 @@ MediaRecorder.prototype = {
   /**
    * Remove event listener.
    *
-   * @param {"start"|"stop"|"pause"|"resume"|"dataavailable"|"error"} type Event type.
+   * @param {"start"|"stop"|"pause"|"resume"|"dataavailable"|"error"}
+   * type Event type.
    * @param {function} listener The same function used in `addEventListener`.
    *
    * @return {undefined}
@@ -221,24 +263,6 @@ MediaRecorder.prototype = {
    */
   dispatchEvent: function dispatchEvent () {
     this.em.dispatchEvent.apply(this.em, arguments)
-  },
-
-  /**
-   * Calls each of the listeners registered for the 'error' event
-   *
-   * @param {Error} error The error object.
-   *
-   * @return {boolean} Is event was no canceled by any listener.
-   */
-  dispatchError: function dispatchError (error) {
-    var event = new Event('error')
-    if (error.message) {
-      event.data = {
-        message: error.message
-      }
-    }
-
-    this.em.dispatchEvent(event)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -12,13 +12,13 @@ function createWorker (fn) {
 /**
  * Create a new Event of type 'error'
  *
- * @param {String} message The error message
+ * @param {String} method The method that failed
  * @return {Event} The error event
  */
-function MediaRecorderErrorEvent (message) {
+function MediaRecorderErrorEvent (method) {
   var event = new Event('error')
   event.data = {
-    message: message
+    message: 'Failed to execute \'' + method + '\''
   }
 
   return event
@@ -89,10 +89,7 @@ MediaRecorder.prototype = {
   start: function start (timeslice) {
     if (this.state !== 'inactive') {
       return this.em.dispatchEvent(
-        MediaRecorderErrorEvent(
-          "Failed to execute 'start' on the MediaRecorder:" +
-          "The MediaRecorder's state is not 'inactive'."
-        )
+        MediaRecorderErrorEvent('start')
       )
     }
 
@@ -140,10 +137,7 @@ MediaRecorder.prototype = {
   stop: function stop () {
     if (this.state === 'inactive') {
       return this.em.dispatchEvent(
-        MediaRecorderErrorEvent(
-          "Failed to execute 'stop' on the MediaRecorder:" +
-          "The MediaRecorder's state is 'inactive'."
-        )
+        MediaRecorderErrorEvent('stop')
       )
     }
 
@@ -165,10 +159,7 @@ MediaRecorder.prototype = {
   pause: function pause () {
     if (this.state !== 'recording') {
       return this.em.dispatchEvent(
-        MediaRecorderErrorEvent(
-          "Failed to execute 'pause' on the MediaRecorder:" +
-          "The MediaRecorder's state is not 'recording'."
-        )
+        MediaRecorderErrorEvent('pause')
       )
     }
 
@@ -189,10 +180,7 @@ MediaRecorder.prototype = {
   resume: function resume () {
     if (this.state !== 'paused') {
       return this.em.dispatchEvent(
-        MediaRecorderErrorEvent(
-          "Failed to execute 'resume' on the MediaRecorder:" +
-          "The MediaRecorder's state is not 'paused'."
-        )
+        MediaRecorderErrorEvent('resume')
       )
     }
 
@@ -213,10 +201,7 @@ MediaRecorder.prototype = {
   requestData: function requestData () {
     if (this.state === 'inactive') {
       return this.em.dispatchEvent(
-        MediaRecorderErrorEvent(
-          "Failed to execute 'requestData' on the MediaRecorder:" +
-          "The MediaRecorder's state is 'inactive'."
-        )
+        MediaRecorderErrorEvent('requestData')
       )
     }
 


### PR DESCRIPTION
This PR adds support for an `error` event type (#13)

By adding an event listener to `"error"`, users will be able to capture errors thrown throughout the MediaRecorder lifecycle.

This PR throws some rudimentary errors, and tries to follow the same message format as the Chrome implementation of MediaRecorder. More errors could be thrown in the future, should we need to.