### PR TITLE
Fix not firing onaudioprocess

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function error (method) {
   return event
 }
 
-var context
+var context, processor
 
 /**
  * Audio Recorder with MediaRecorder API.
@@ -92,7 +92,7 @@ MediaRecorder.prototype = {
     }
     this.clone = this.stream.clone()
     var input = context.createMediaStreamSource(this.clone)
-    var processor = context.createScriptProcessor(2048, 1, 1)
+    processor = context.createScriptProcessor(2048, 1, 1)
 
     var recorder = this
     processor.onaudioprocess = function (e) {


### PR DESCRIPTION
This PR fix that `processor.onaudioprocess` is not being fired in mobile Safari. ( #4 )

This problem is maybe caused by garbage collection.
https://stackoverflow.com/questions/14521170/safari-6-0-2-not-calling-onaudioprocess
