### PR TITLE
Regex fix, worker function string replace

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ let AudioContext = window.AudioContext || window.webkitAudioContext
 function createWorker (fn) {
   let js = fn
     .toString()
-    .replace(/^(\(\)\s+=>|function\s*\(\))\s*{/, '')
+    .replace(/^(\(\)\s*=>|function\s*\(\))\s*{/, '')
     .replace(/}$/, '')
   let blob = new Blob([js])
   return new Worker(URL.createObjectURL(blob))


### PR DESCRIPTION
In `createWorker(fn)` function, it make `MediaRecorder.encoder`'s string and send it as blob.

I'm using webpack 4 and this is what I get  by `console.log(fn.toString())`;

```
()=>{let e=[];onmessage=t=>{"encode"===t.data[0]?function(t){let n=t.length,r=new Uint8Array(2*n);for(let e=0;e<n;e++){let n=2*e,s=t[e];s>1?s=1:s<-1&&(s=-1),s*=32768,r[n]=s,r[n+1]=s>>8}e.push(r)}(t.data[1]):function(t){let n=e.length?e[0].length:0,r=e.length*n,s=new Uint8Array(44+r),i=new DataView(s.buffer);i.setUint32(0,1380533830,!1),i.setUint32(4,36+r,!0),i.setUint32(8,1463899717,!1),i.setUint32(12,1718449184,!1),i.setUint32(16,16,!0),i.setUint16(20,1,!0),i.setUint16(22,1,!0),i.setUint32(24,t,!0),i.setUint32(28,2*t,!0),i.setUint16(32,2,!0),i.setUint16(34,16,!0),i.setUint32(36,1684108385,!1),i.setUint32(40,r,!0);for(let t=0;t<e.length;t++)s.set(e[t],t*n+44);e=[],postMessage(s.buffer,[s.buffer])}(t.data[1])}
```

The regex needs to be fixed with `\s*` when checking arrow functions.