### PR TITLE
disconnect mediaStreamSource input in stop function to prevent echo bug in Safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,9 +135,7 @@ class MediaRecorder {
     this.clone.getTracks().forEach(track => {
       track.stop()
     })
-    if (this.input && typeof this.input === 'function') {
-      this.input.disconnect();
-    }
+    this.input.disconnect()
     return clearInterval(this.slicing)
   }
 

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ class MediaRecorder {
       context = new AudioContext()
     }
     this.clone = this.stream.clone()
-    let input = context.createMediaStreamSource(this.clone)
+    this.input = context.createMediaStreamSource(this.clone)
 
     if (!processor) {
       processor = context.createScriptProcessor(2048, 1, 1)
@@ -101,7 +101,7 @@ class MediaRecorder {
       }
     }
 
-    input.connect(processor)
+    this.input.connect(processor)
     processor.connect(context.destination)
 
     this.em.dispatchEvent(new Event('start'))
@@ -135,6 +135,7 @@ class MediaRecorder {
     this.clone.getTracks().forEach(track => {
       track.stop()
     })
+    this.input.disconnect();
     return clearInterval(this.slicing)
   }
 

--- a/index.js
+++ b/index.js
@@ -135,7 +135,9 @@ class MediaRecorder {
     this.clone.getTracks().forEach(track => {
       track.stop()
     })
-    this.input.disconnect();
+    if (this.input && typeof this.input === 'function') {
+      this.input.disconnect();
+    }
     return clearInterval(this.slicing)
   }
 

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,12 +1,21 @@
 navigator.mediaDevices = { }
 
+class AudioNode {
+  connect () { }
+
+  disconnect () { }
+}
+
+class ScriptProcessorNode extends AudioNode {}
+class MediaStreamAudioSourceNode extends AudioNode {}
+
 class AudioContext {
   createScriptProcessor () {
-    return { connect () { } }
+    return new ScriptProcessorNode()
   }
 
   createMediaStreamSource () {
-    return { connect () { } }
+    return new MediaStreamAudioSourceNode()
   }
 }
 global.AudioContext = AudioContext


### PR DESCRIPTION
First off, thanks for this great module and the effort it takes to maintain it.

Quick background: I'm using this module to record speech commands on a private fork of https://github.com/petewarden/open-speech-recording. This means I'm starting and stopping around 100 times per session.

In Safari, which is crucial for me to support, the first audio file was always perfectly fine, then progressively worse with every recording.

Here's 3 demonstration files of the issue: [Issue example files.zip](https://github.com/ai/audio-recorder-polyfill/files/4474151/Issue.example.files.zip)
- one file demonstrates the echo really well (`Down_echo_obvious.wav`). This is what got me thinking there was a a problem disconnecting the input and processor.
- the other two files, both of the 11th recorded word in a series on MacOS Safari, the only difference is with/without the fix in this PR. Here you can see how bad the audio gets after a while.

These recordings are all from Safari 13.0.5 on MacOS, but solves the issue for Safari on iOS 13.3.1 as well.

I'm not sure what causes this, but my best guess is that the processor still receives input from every input created with `context.createMediaStreamSource(this.clone)`. According to [ScriptProcessorNode docs on MDN](https://developer.mozilla.org/en-US/docs/Web/API/ScriptProcessorNode) the processor should just have 1 input and 1 output, but perhaps Safari fails to enforce this. Printing the numberOfInputs and numberOfOutput properties of `input` and `processor` (which are both AudioNodes), didn't reveal any issue, however disconnecting the input on stop solved my problem.