### PR TITLE
add AudioContext init config params

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ class MediaRecorder {
      * @type {MediaStream}
      */
     this.stream = stream
-    this.config = config || {}
+    this.config = config
     /**
      * The current state of recording process.
      * @type {"inactive"|"recording"|"paused"}

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ class MediaRecorder {
   /**
    * @param {MediaStream} stream The audio stream to record.
    */
-  constructor (stream, config) {
+  constructor (stream, config = null) {
     /**
      * The `MediaStream` passed into the constructor.
      * @type {MediaStream}

--- a/index.js
+++ b/index.js
@@ -31,13 +31,13 @@ class MediaRecorder {
   /**
    * @param {MediaStream} stream The audio stream to record.
    */
-  constructor (stream) {
+  constructor (stream, config) {
     /**
      * The `MediaStream` passed into the constructor.
      * @type {MediaStream}
      */
     this.stream = stream
-
+    this.config = config || {}
     /**
      * The current state of recording process.
      * @type {"inactive"|"recording"|"paused"}
@@ -80,7 +80,7 @@ class MediaRecorder {
     this.state = 'recording'
 
     if (!context) {
-      context = new AudioContext()
+      context = new AudioContext(this.config ? this.config : null)
     }
     this.clone = this.stream.clone()
     this.input = context.createMediaStreamSource(this.clone)

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ class MediaRecorder {
     this.state = 'recording'
 
     if (!context) {
-      context = new AudioContext(this.config ? this.config : null)
+      context = new AudioContext(this.config)
     }
     this.clone = this.stream.clone()
     this.input = context.createMediaStreamSource(this.clone)

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "1.1 KB"
+      "limit": "1.12 KB"
     }
   ],
   "eslintConfig": {


### PR DESCRIPTION
add AudioContext init config params.For example,
 `new window.MediaRecorder(stream, {
      sampleRate: 16000
  })`
That can set audio's sampleRate When init The MediaRecorder