### PR TITLE
Fix Safari playback icon showing indefinitely after recording

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,7 +30,7 @@ function waitForData (recorder) {
   })
 }
 
-let processor = { connect () {}, a: 1 }
+let processor = { connect () {}, disconnect () {}, a: 1 }
 AudioContext.prototype.createScriptProcessor = () => {
   return processor
 }


### PR DESCRIPTION
First of all, thank you for making this library.
I'm using it a lot in one of my projects.

I noticed that, in Safari, after recording some audio, the audio recording icon (mic icon) in the url bar is replaced by the audio playback icon (speaker icon) indefinitely, and there's no way to remove it unless you reload the page.

You can see it happen in the [demo page](https://ai.github.io/audio-recorder-polyfill/).

![Screen Shot 2020-11-19 at 12 47 38](https://user-images.githubusercontent.com/1836719/99618829-7d77d180-2a65-11eb-8f5b-adddd4c552a2.png)

It seems the audio context destination isn't released in Safari unless you call `disconnect()` in the processor node.

This issue doesn't seem to occur in Chrome nor Firefox, and doesn't seem to affect the recording in any way as far as I can see though.